### PR TITLE
Støtte oppslag på flere ressurser

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.8-SNAPSHOT"
+version = "0.0.8"
 
 kotlin {
     compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.7"
+version = "0.0.8-SNAPSHOT"
 
 kotlin {
     compilerOptions {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/HttpUtils.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/HttpUtils.kt
@@ -55,6 +55,5 @@ private fun Throwable.isRetryableException() =
         is SocketTimeoutException -> true
         is ConnectTimeoutException -> true
         is HttpRequestTimeoutException -> true
-        is java.net.SocketTimeoutException -> true
         else -> false
     }

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpClient.kt
@@ -10,7 +10,6 @@ import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 class PdpClient(
     private val baseUrl: String,
     private val subscriptionKey: String,
-    private val ressurs: String,
     private val getToken: () -> String,
 ) {
     private val httpClient = createHttpClient(3, getToken)
@@ -21,16 +20,19 @@ class PdpClient(
     suspend fun personHarRettighetForOrganisasjon(
         fnr: String,
         orgnr: String,
-    ): Boolean = pdpKall(Person(fnr), orgnr).getOrThrow().harTilgang()
+        ressurs: String,
+    ): Boolean = pdpKall(Person(fnr), orgnr, ressurs).getOrThrow().harTilgang()
 
     suspend fun systemHarRettighetForOrganisasjon(
         systembrukerId: String,
         orgnr: String,
-    ): Boolean = pdpKall(System(systembrukerId), orgnr).getOrThrow().harTilgang()
+        ressurs: String,
+    ): Boolean = pdpKall(System(systembrukerId), orgnr, ressurs).getOrThrow().harTilgang()
 
     private suspend fun pdpKall(
         bruker: Bruker,
         orgnr: String,
+        ressurs: String,
     ): Result<PdpResponse> {
         val pdpRequest = lagPdpRequest(bruker, orgnr, ressurs)
         val pdpResponseResult: Result<PdpResponse> =

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/MockPdpClient.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/MockPdpClient.kt
@@ -25,6 +25,6 @@ fun mockPdpClient(
     val mockHttpClient = HttpClient(mockEngine) { configure(1) { "" } }
     return mockStatic(::createHttpClient) {
         every { createHttpClient(any(), any()) } returns mockHttpClient
-        PdpClient("url", "key", "test_ressurs") { "" }
+        PdpClient("url", "key") { "" }
     }
 }

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpClientTest.kt
@@ -9,25 +9,25 @@ class PdpClientTest :
     FunSpec({
         test("Pdp oppslag gir Permit") {
             val pdpClient = mockPdpClient(HttpStatusCode.Created, MockData.permitResponseString)
-            pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, MockData.orgnr) shouldBe true
+            pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, MockData.orgnr, MockData.ressurs) shouldBe true
         }
 
         test("Håndterer hvis kallet timer ut") {
             val pdpClient = mockPdpClient(HttpStatusCode.GatewayTimeout)
             shouldThrowExactly<PdpClientException> {
-                pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, MockData.orgnr)
+                pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, MockData.orgnr, MockData.ressurs)
             }
         }
 
         test("Pdp oppslag for personbruker gir Permit") {
             val pdpClient = mockPdpClient(HttpStatusCode.Created, MockData.permitResponseString)
-            pdpClient.systemHarRettighetForOrganisasjon(MockData.systembrukerId, MockData.orgnr) shouldBe true
+            pdpClient.systemHarRettighetForOrganisasjon(MockData.systembrukerId, MockData.orgnr, MockData.ressurs) shouldBe true
         }
 
         test("Kaster feil ved Unauthorized") {
             val pdpClient = mockPdpClient(HttpStatusCode.Unauthorized)
             shouldThrowExactly<PdpClientException> {
-                pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, MockData.orgnr)
+                pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, MockData.orgnr, MockData.ressurs)
             }
         }
     })


### PR DESCRIPTION
Tidligere ble pdp-klienten opprettet med en gitt ressurs som aldri kunne endres - endrer til at ressurs sendes inn ved hvert oppslag