### PR TITLE
Legg til støtte for å sjekke tilgang for flere orgnr i ett pdp-kall

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.10-SNAPSHOT"
+version = "0.0.10-v2-SNAPSHOT"
 
 kotlin {
     compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.10-v3-SNAPSHOT"
+version = "0.0.10"
 
 kotlin {
     compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.10-v2-SNAPSHOT"
+version = "0.0.10-v3-SNAPSHOT"
 
 kotlin {
     compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.9"
+version = "0.0.10-SNAPSHOT"
 
 kotlin {
     compilerOptions {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("maven-publish")
 }
 group = "no.nav.helsearbeidsgiver"
-version = "0.0.10"
+version = "1.0.0"
 
 kotlin {
     compilerOptions {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpClient.kt
@@ -17,7 +17,7 @@ class PdpClient(
     private val logger = this.logger()
     private val sikkerLogger = sikkerLogger()
 
-    suspend fun personHarRettighetForOrganisasjon(
+    suspend fun personHarRettighetForOrganisasjoner(
         fnr: String,
         orgnumre: Set<String>,
         ressurs: String,

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpClient.kt
@@ -19,55 +19,29 @@ class PdpClient(
 
     suspend fun personHarRettighetForOrganisasjon(
         fnr: String,
-        orgnr: String,
+        orgnumre: Set<String>,
         ressurs: String,
-    ): Boolean = pdpKall(Person(fnr), orgnr, ressurs).getOrThrow().harTilgang()
-
-    suspend fun systemHarRettighetForOrganisasjon(
-        systembrukerId: String,
-        orgnr: String,
-        ressurs: String,
-    ): Boolean = pdpKall(System(systembrukerId), orgnr, ressurs).getOrThrow().harTilgang()
+    ): Boolean = pdpKall(Person(fnr), orgnumre, ressurs).getOrThrow().harTilgang()
 
     suspend fun systemHarRettighetForOrganisasjoner(
         systembrukerId: String,
-        orgnrSet: Set<String>,
+        orgnumre: Set<String>,
         ressurs: String,
-    ): Boolean = pdpKall(System(systembrukerId), orgnrSet, ressurs).getOrThrow().harTilgang()
+    ): Boolean = pdpKall(System(systembrukerId), orgnumre, ressurs).getOrThrow().harTilgang()
 
     private suspend fun pdpKall(
         bruker: Bruker,
-        orgnr: String,
+        orgnumre: Set<String>,
         ressurs: String,
     ): Result<PdpResponse> {
-        val pdpRequest = lagPdpRequest(bruker, orgnr, ressurs)
-        sikkerLogger.info("PDP kall for $ressurs: $pdpRequest")
-        val pdpResponseResult: Result<PdpResponse> =
-            runCatching<PdpClient, PdpResponse> {
-                httpClient
-                    .post("$baseUrl/authorization/api/v1/authorize") {
-                        header("Ocp-Apim-Subscription-Key", subscriptionKey)
-                        header("Content-Type", "application/json")
-                        header("Accept", "application/json")
-                        setBody(pdpRequest)
-                    }.body()
-            }.recover { e ->
-                "Feil ved kall til pdp endepunkt".also {
-                    logger.error(it)
-                    sikkerLogger.error(it, e)
-                }
-                throw PdpClientException()
+        if (orgnumre.isEmpty()) {
+            "Ingen organisasjonsnumre gitt for pdp-kall".also {
+                logger.warn(it)
+                sikkerLogger.warn(it)
+                throw IllegalArgumentException(it)
             }
-        sikkerLogger.info("PDP respons: $pdpResponseResult")
-        return pdpResponseResult
-    }
-
-    private suspend fun pdpKall(
-        bruker: Bruker,
-        orgnrSet: Set<String>,
-        ressurs: String,
-    ): Result<PdpResponse> {
-        val pdpRequest = lagPdpRequest(bruker, orgnrSet, ressurs)
+        }
+        val pdpRequest = lagPdpRequest(bruker, orgnumre, ressurs)
         sikkerLogger.info("PDP kall for $ressurs: $pdpRequest")
         val pdpResponseResult: Result<PdpResponse> =
             runCatching<PdpClient, PdpResponse> {

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpRequest.kt
@@ -42,58 +42,6 @@ class System(
 
 fun lagPdpRequest(
     bruker: Bruker,
-    orgnr: String,
-    ressurs: String,
-) = PdpRequest(
-    request =
-        PdpRequest.XacmlJsonRequestExternal(
-            returnPolicyIdList = true,
-            accessSubject =
-                listOf(
-                    PdpRequest.XacmlJsonCategoryExternal(
-                        attribute =
-                            listOf(
-                                PdpRequest.XacmlJsonAttributeExternal(
-                                    attributeId = bruker.attributeId,
-                                    value = bruker.id,
-                                ),
-                            ),
-                    ),
-                ),
-            action =
-                listOf(
-                    PdpRequest.XacmlJsonCategoryExternal(
-                        attribute =
-                            listOf(
-                                PdpRequest.XacmlJsonAttributeExternal(
-                                    attributeId = "urn:oasis:names:tc:xacml:1.0:action:action-id",
-                                    value = "access",
-                                    dataType = "http://www.w3.org/2001/XMLSchema#string",
-                                ),
-                            ),
-                    ),
-                ),
-            resource =
-                listOf(
-                    PdpRequest.XacmlJsonCategoryExternal(
-                        attribute =
-                            listOf(
-                                PdpRequest.XacmlJsonAttributeExternal(
-                                    attributeId = "urn:altinn:resource",
-                                    value = ressurs,
-                                ),
-                                PdpRequest.XacmlJsonAttributeExternal(
-                                    attributeId = "urn:altinn:organization:identifier-no",
-                                    value = orgnr,
-                                ),
-                            ),
-                    ),
-                ),
-        ),
-)
-
-fun lagPdpRequest(
-    bruker: Bruker,
     orgnrSet: Set<String>,
     ressurs: String,
 ) = PdpRequest(

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpRequest.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpRequest.kt
@@ -91,3 +91,55 @@ fun lagPdpRequest(
                 ),
         ),
 )
+
+fun lagPdpRequest(
+    bruker: Bruker,
+    orgnrSet: Set<String>,
+    ressurs: String,
+) = PdpRequest(
+    request =
+        PdpRequest.XacmlJsonRequestExternal(
+            returnPolicyIdList = true,
+            accessSubject =
+                listOf(
+                    PdpRequest.XacmlJsonCategoryExternal(
+                        attribute =
+                            listOf(
+                                PdpRequest.XacmlJsonAttributeExternal(
+                                    attributeId = bruker.attributeId,
+                                    value = bruker.id,
+                                ),
+                            ),
+                    ),
+                ),
+            action =
+                listOf(
+                    PdpRequest.XacmlJsonCategoryExternal(
+                        attribute =
+                            listOf(
+                                PdpRequest.XacmlJsonAttributeExternal(
+                                    attributeId = "urn:oasis:names:tc:xacml:1.0:action:action-id",
+                                    value = "access",
+                                    dataType = "http://www.w3.org/2001/XMLSchema#string",
+                                ),
+                            ),
+                    ),
+                ),
+            resource =
+                orgnrSet.map { orgnr ->
+                    PdpRequest.XacmlJsonCategoryExternal(
+                        attribute =
+                            listOf(
+                                PdpRequest.XacmlJsonAttributeExternal(
+                                    attributeId = "urn:altinn:resource",
+                                    value = ressurs,
+                                ),
+                                PdpRequest.XacmlJsonAttributeExternal(
+                                    attributeId = "urn:altinn:organization:identifier-no",
+                                    value = orgnr,
+                                ),
+                            ),
+                    )
+                },
+        ),
+)

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/MockData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/MockData.kt
@@ -5,12 +5,13 @@ import no.nav.helsearbeidsgiver.utils.json.jsonConfig
 object MockData {
     val fnr = "01017012345"
     val orgnr = "312824450"
+    val orgnumre = setOf(orgnr, "123456789")
     val systembrukerId = "1234"
     val person = Person(fnr)
     val system = System(systembrukerId)
     val ressurs = "nav_sykepenger_inntektsmelding-nedlasting"
-    val pdpPersonRequest = lagPdpRequest(person, orgnr, ressurs)
-    val pdpSystemRequest = lagPdpRequest(system, orgnr, ressurs)
+    val pdpPersonRequest = lagPdpRequest(person, setOf(orgnr), ressurs)
+    val pdpSystemRequest = lagPdpRequest(system, orgnumre, ressurs)
     val permitResponseString: String =
         jsonConfig.encodeToString(
             PdpResponse.serializer(),

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/MockData.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/MockData.kt
@@ -9,8 +9,8 @@ object MockData {
     val systembrukerId = "1234"
     val person = Person(fnr)
     val system = System(systembrukerId)
-    val ressurs = "nav_sykepenger_inntektsmelding-nedlasting"
-    val pdpPersonRequest = lagPdpRequest(person, setOf(orgnr), ressurs)
+    val ressurs = "nav_system_sykepenger_inntektsmelding"
+    val pdpPersonRequest = lagPdpRequest(person, orgnumre, ressurs)
     val pdpSystemRequest = lagPdpRequest(system, orgnumre, ressurs)
     val permitResponseString: String =
         jsonConfig.encodeToString(

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpClientTest.kt
@@ -9,31 +9,40 @@ class PdpClientTest :
     FunSpec({
         test("Pdp oppslag for personbruker gir Permit") {
             val pdpClient = mockPdpClient(HttpStatusCode.Created, MockData.permitResponseString)
-            pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, MockData.orgnumre, MockData.ressurs) shouldBe true
+            pdpClient.personHarRettighetForOrganisasjoner(MockData.fnr, MockData.orgnumre, MockData.ressurs) shouldBe true
         }
 
         test("Håndterer hvis personbruker-kallet timer ut") {
             val pdpClient = mockPdpClient(HttpStatusCode.GatewayTimeout)
             shouldThrowExactly<PdpClientException> {
-                pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, MockData.orgnumre, MockData.ressurs)
+                pdpClient.personHarRettighetForOrganisasjoner(MockData.fnr, MockData.orgnumre, MockData.ressurs)
             }
         }
 
         test("Kaster feil ved Unauthorized for personbruker") {
             val pdpClient = mockPdpClient(HttpStatusCode.Unauthorized)
             shouldThrowExactly<PdpClientException> {
-                pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, MockData.orgnumre, MockData.ressurs)
+                pdpClient.personHarRettighetForOrganisasjoner(MockData.fnr, MockData.orgnumre, MockData.ressurs)
             }
         }
 
         test("Kaster feil dersom man ikke gir organisasjonsnumre for personbruker") {
             val pdpClient = mockPdpClient(HttpStatusCode.Created, MockData.permitResponseString)
             shouldThrowExactly<IllegalArgumentException> {
-                pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, emptySet(), MockData.ressurs)
+                pdpClient.personHarRettighetForOrganisasjoner(MockData.fnr, emptySet(), MockData.ressurs)
             }
         }
 
-        test("Pdp oppslag for systembruker gir Permit") {
+        test("Pdp oppslag for systembruker med ett orgnummer gir Permit") {
+            val pdpClient = mockPdpClient(HttpStatusCode.Created, MockData.permitResponseString)
+            pdpClient.systemHarRettighetForOrganisasjoner(
+                MockData.systembrukerId,
+                setOf(MockData.orgnr),
+                MockData.ressurs,
+            ) shouldBe true
+        }
+
+        test("Pdp oppslag for systembruker med flere orgnumre gir Permit") {
             val pdpClient = mockPdpClient(HttpStatusCode.Created, MockData.permitResponseString)
             pdpClient.systemHarRettighetForOrganisasjoner(
                 MockData.systembrukerId,

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpClientTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpClientTest.kt
@@ -7,27 +7,71 @@ import io.ktor.http.HttpStatusCode
 
 class PdpClientTest :
     FunSpec({
-        test("Pdp oppslag gir Permit") {
+        test("Pdp oppslag for personbruker gir Permit") {
             val pdpClient = mockPdpClient(HttpStatusCode.Created, MockData.permitResponseString)
-            pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, MockData.orgnr, MockData.ressurs) shouldBe true
+            pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, MockData.orgnumre, MockData.ressurs) shouldBe true
         }
 
-        test("Håndterer hvis kallet timer ut") {
+        test("Håndterer hvis personbruker-kallet timer ut") {
             val pdpClient = mockPdpClient(HttpStatusCode.GatewayTimeout)
             shouldThrowExactly<PdpClientException> {
-                pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, MockData.orgnr, MockData.ressurs)
+                pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, MockData.orgnumre, MockData.ressurs)
             }
         }
 
-        test("Pdp oppslag for personbruker gir Permit") {
-            val pdpClient = mockPdpClient(HttpStatusCode.Created, MockData.permitResponseString)
-            pdpClient.systemHarRettighetForOrganisasjon(MockData.systembrukerId, MockData.orgnr, MockData.ressurs) shouldBe true
-        }
-
-        test("Kaster feil ved Unauthorized") {
+        test("Kaster feil ved Unauthorized for personbruker") {
             val pdpClient = mockPdpClient(HttpStatusCode.Unauthorized)
             shouldThrowExactly<PdpClientException> {
-                pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, MockData.orgnr, MockData.ressurs)
+                pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, MockData.orgnumre, MockData.ressurs)
+            }
+        }
+
+        test("Kaster feil dersom man ikke gir organisasjonsnumre for personbruker") {
+            val pdpClient = mockPdpClient(HttpStatusCode.Created, MockData.permitResponseString)
+            shouldThrowExactly<IllegalArgumentException> {
+                pdpClient.personHarRettighetForOrganisasjon(MockData.fnr, emptySet(), MockData.ressurs)
+            }
+        }
+
+        test("Pdp oppslag for systembruker gir Permit") {
+            val pdpClient = mockPdpClient(HttpStatusCode.Created, MockData.permitResponseString)
+            pdpClient.systemHarRettighetForOrganisasjoner(
+                MockData.systembrukerId,
+                MockData.orgnumre,
+                MockData.ressurs,
+            ) shouldBe true
+        }
+
+        test("Håndterer hvis systembruker-kallet timer ut") {
+            val pdpClient = mockPdpClient(HttpStatusCode.GatewayTimeout)
+            shouldThrowExactly<PdpClientException> {
+                pdpClient.systemHarRettighetForOrganisasjoner(
+                    MockData.systembrukerId,
+                    MockData.orgnumre,
+                    MockData.ressurs,
+                )
+            }
+        }
+
+        test("Kaster feil ved Unauthorized for systembruker") {
+            val pdpClient = mockPdpClient(HttpStatusCode.Unauthorized)
+            shouldThrowExactly<PdpClientException> {
+                pdpClient.systemHarRettighetForOrganisasjoner(
+                    MockData.systembrukerId,
+                    MockData.orgnumre,
+                    MockData.ressurs,
+                )
+            }
+        }
+
+        test("Kaster feil dersom man ikke gir organisasjonsnumre for systembruker") {
+            val pdpClient = mockPdpClient(HttpStatusCode.Created, MockData.permitResponseString)
+            shouldThrowExactly<IllegalArgumentException> {
+                pdpClient.systemHarRettighetForOrganisasjoner(
+                    MockData.systembrukerId,
+                    emptySet(),
+                    MockData.ressurs,
+                )
             }
         }
     })

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpRequestTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpRequestTest.kt
@@ -11,7 +11,7 @@ class PdpRequestTest :
             requestString shouldContain MockData.fnr
             requestString shouldContain "nav_sykepenger_inntektsmelding-nedlasting"
             requestString shouldContain "urn:altinn:person:identifier-no"
-            requestString shouldContain MockData.orgnr
+            MockData.orgnumre.forEach { requestString shouldContain it }
         }
 
         test("Serialialiser request for systembruker riktig") {

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpRequestTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpRequestTest.kt
@@ -19,6 +19,6 @@ class PdpRequestTest :
             requestString shouldContain MockData.systembrukerId
             requestString shouldContain "nav_sykepenger_inntektsmelding-nedlasting"
             requestString shouldContain "urn:altinn:systemuser:uuid"
-            requestString shouldContain MockData.orgnr
+            MockData.orgnumre.forEach { requestString shouldContain it }
         }
     })

--- a/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpRequestTest.kt
+++ b/src/test/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpRequestTest.kt
@@ -9,7 +9,7 @@ class PdpRequestTest :
         test("Serialialiser request for person riktig") {
             val requestString = jsonConfig.encodeToString(PdpRequest.serializer(), MockData.pdpPersonRequest)
             requestString shouldContain MockData.fnr
-            requestString shouldContain "nav_sykepenger_inntektsmelding-nedlasting"
+            requestString shouldContain "nav_system_sykepenger_inntektsmelding"
             requestString shouldContain "urn:altinn:person:identifier-no"
             MockData.orgnumre.forEach { requestString shouldContain it }
         }
@@ -17,7 +17,7 @@ class PdpRequestTest :
         test("Serialialiser request for systembruker riktig") {
             val requestString = jsonConfig.encodeToString(PdpRequest.serializer(), MockData.pdpSystemRequest)
             requestString shouldContain MockData.systembrukerId
-            requestString shouldContain "nav_sykepenger_inntektsmelding-nedlasting"
+            requestString shouldContain "nav_system_sykepenger_inntektsmelding"
             requestString shouldContain "urn:altinn:systemuser:uuid"
             MockData.orgnumre.forEach { requestString shouldContain it }
         }


### PR DESCRIPTION
**Bakgrunn**
Vi innså at vi får en mer forståelig kode i LPS-APIet vårt dersom vi bruker både orgnr fra token og orgnr fra request/forespørsel i kallet til pdp. Se https://github.com/navikt/sykepenger-im-lps-api/pull/147 for kontekst.

**Løsning**
Gå fra å sjekke ett orgnr av gangen til å sjekke om man har tilgang med et sett av orgnr. Man må ha tilgang til alle orgnr i settet for å få permit fra pdp. Dersom vi får inn et tomt sett med orgnr tryner vi hardt med `IllegalArgumentException` for å sikre at vi ikke gir noen tilgang ved en feil fordi det ikke kommer med noe orgnr i pdp-requesten.