### PR TITLE
Bumper avhengigheter og legger på logging av resultat til åpne logger

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,15 @@
 kotlin.code.style=official
 
 group=no.nav.helsearbeidsgiver
-version=1.1.0
+version=1.1.1
 
 # Plugin versions
 kotlinterVersion=5.2.0
 
 # Dependency versions
-kotlinVersion=2.2.21
-ktorVersion=3.3.1
-utilsVersion=0.10.1
-kotestVersion=6.0.4
-kotlinxSerializationVersion=1.9.0
-mockkVersion=1.14.6
+kotlinVersion=2.4.0
+ktorVersion=3.4.0
+utilsVersion=0.10.2
+kotestVersion=6.1.11
+kotlinxSerializationVersion=1.11.0
+mockkVersion=1.14.11

--- a/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpClient.kt
+++ b/src/main/kotlin/no/nav/helsearbeidsgiver/altinn/pdp/PdpClient.kt
@@ -78,6 +78,9 @@ class PdpClient(
                 throw PdpClientException()
             }
         sikkerLogger.debug("PDP respons: $pdpResponseResult")
+        pdpResponseResult.getOrNull()?.also {
+            logger.debug("PDP respons har tilgang: ${it.harTilgang()}")
+        }
         return pdpResponseResult
     }
 }


### PR DESCRIPTION
* Bump avhengigheter
* Logg resultatet til åpne logger (true/false) så man kan se det i tracing fra hag-dokument-proxy